### PR TITLE
Only console.log from IsSilence if debug is true

### DIFF
--- a/lib/mic.js
+++ b/lib/mic.js
@@ -17,7 +17,7 @@ var mic = function mic(options) {
     var format, formatEndian, formatEncoding;
     var audioProcess = null;
     var infoStream = new PassThrough;
-    var audioStream = new IsSilence;
+    var audioStream = new IsSilence({debug: debug});
     var audioProcessOptions = {
         stdio: ['ignore', 'pipe', 'ignore']
     };

--- a/lib/silenceTransform.js
+++ b/lib/silenceTransform.js
@@ -3,6 +3,10 @@ var util = require("util");
 
 function IsSilence(options) {
     var that = this;
+    if (options && options.debug) {
+      that.debug = options.debug;
+      delete options.debug;
+    }
     Transform.call(that, options);
     var consecSilenceCount = 0;
     var numSilenceFramesExitThresh = 0;
@@ -37,6 +41,7 @@ IsSilence.prototype._transform = function(chunk, encoding, callback) {
     var speechSample;
     var silenceLength = 0;
     var self = this;
+    var debug = this.debug;
     var consecutiveSilence = self.getConsecSilenceCount();
     var numSilenceFramesExitThresh = self.getNumSilenceFramesExitThresh();
     var incrementConsecSilence = self.incrConsecSilenceCount;
@@ -52,7 +57,7 @@ IsSilence.prototype._transform = function(chunk, encoding, callback) {
             speechSample += chunk[i];
 
             if(Math.abs(speechSample) > 2000) {
-                console.log("Found speech block");
+                if (debug) console.log("Found speech block");
                 resetConsecSilence();
                 break;
             } else {
@@ -62,7 +67,7 @@ IsSilence.prototype._transform = function(chunk, encoding, callback) {
         }
         if(silenceLength == chunk.length/2) {
             consecutiveSilence = incrementConsecSilence();
-            console.log("Found silence block: %d of %d", consecutiveSilence, numSilenceFramesExitThresh);
+            if (debug) console.log("Found silence block: %d of %d", consecutiveSilence, numSilenceFramesExitThresh);
             //emit 'silence' only once each time the threshold condition is met
             if( consecutiveSilence === numSilenceFramesExitThresh) {
                 self.emit('silence');


### PR DESCRIPTION
Pass the debug option given to `mic({debug: true})` into IsSilence so that `console.log` is only called from within IsSilence when debug is true.