### PR TITLE
add fileType option to sox command on OSX

### DIFF
--- a/lib/mic.js
+++ b/lib/mic.js
@@ -13,6 +13,7 @@ var mic = function mic(options) {
     var channels = options.channels || '1';
     var device = options.device || 'plughw:1,0';
     var exitOnSilence = options.exitOnSilence || 0;
+    var fileType = options.fileType || 'raw';
     var debug = options.debug || false;
     var format, formatEndian, formatEncoding;
     var audioProcess = null;
@@ -43,7 +44,7 @@ var mic = function mic(options) {
     that.start = function start() {
         if(audioProcess === null) {
             audioProcess = isMac
-            ? spawn('rec', ['-b', bitwidth, '--endian', endian, '-c', channels, '-r', rate, '-e', encoding, '-t', 'raw', '-'], audioProcessOptions)
+            ? spawn('rec', ['-b', bitwidth, '--endian', endian, '-c', channels, '-r', rate, '-e', encoding, '-t', fileType, '-'], audioProcessOptions)
             : spawn('arecord', ['-c', channels, '-r', rate, '-f', format, '-D', device], audioProcessOptions);
             audioProcess.on('exit', function(code, sig) {
                     if(code != null && sig === null) {


### PR DESCRIPTION
Using the fileType option to add { fileType: 'wav' } allowed me to output a wav file with the appropriate headers. Might possibly consider this as a default. Tested on OSX 10.11.5