### PR TITLE
added fileType parameter to arecord

### DIFF
--- a/lib/mic.js
+++ b/lib/mic.js
@@ -56,7 +56,7 @@ var mic = function mic(options) {
                                     '-t', fileType, '-'], audioProcessOptions)
             }
             else {
-              audioProcess = spawn('arecord', ['-c', channels, '-r', rate, '-f',
+              audioProcess = spawn('arecord', ['-t', fileType, '-c', channels, '-r', rate, '-f',
                                    format, '-D', device], audioProcessOptions);
             }
 


### PR DESCRIPTION
Added the fileType option (already defaults to raw) as a parameter that gets passed to the spawned `arecord` process. This resolves the issues noted in https://github.com/ashishbajaj99/mic/issues/22.

Without this parameter, `arecord` defaults to WAV format, which has a 2GB file size limit. In situations where a fileType has not been specified and the user wants to run `arecord` continuously, `arecord` eventually exits when it has processed 2GB worth of audio. Now, by default, the audio type will be `raw` (which has no file size limit), meaning that `arecord` will run indefinitely. For any given fileType the user supplies, the expected behavior is that `arecord` will run until it has processed the maximum file size amount of data for that given type.

More info on arecord is available here: https://linux.die.net/man/1/arecord