### PR TITLE
add bufferFrames and periodFrames options for arecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Returns a microphone object instance that can be used to control the streaming s
     * `exitOnSilence`: The `'silence'` signal is raised after reaching these many consecutive frames, default: '0'
     * `debug`: true OR false - can be used to aide in debugging
     * `fileType`: string defaults to 'raw', allows you to set a valid file type such as 'wav' (for sox only) to avoid the no header issue mentioned above, see a list of types [here](http://sox.sourceforge.net/soxformat.html)
+    * `bufferFrames': buffer duration in # frames for arecord.
+    * `periodFrames': distance between interrupts in # frames for arecord.
 
 ### mic.start()
 This instantiates the process `arecord` OR `sox` using the options specified

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Returns a microphone object instance that can be used to control the streaming s
     * `exitOnSilence`: The `'silence'` signal is raised after reaching these many consecutive frames, default: '0'
     * `debug`: true OR false - can be used to aide in debugging
     * `fileType`: string defaults to 'raw', allows you to set a valid file type such as 'wav' (for sox only) to avoid the no header issue mentioned above, see a list of types [here](http://sox.sourceforge.net/soxformat.html)
-    * `bufferFrames': buffer duration in # frames for arecord.
-    * `periodFrames': distance between interrupts in # frames for arecord.
+    * `bufferFrames`: buffer duration in # frames for arecord.
+    * `periodFrames`: distance between interrupts in # frames for arecord.
 
 ### mic.start()
 This instantiates the process `arecord` OR `sox` using the options specified

--- a/lib/mic.js
+++ b/lib/mic.js
@@ -16,6 +16,8 @@ var mic = function mic(options) {
     var exitOnSilence = options.exitOnSilence || 0;
     var fileType = options.fileType || 'raw';
     var debug = options.debug || false;
+    var bufferFrames = options.bufferFrames;
+    var periodFrames = options.periodFrames;
     var format, formatEndian, formatEncoding;
     var audioProcess = null;
     var infoStream = new PassThrough;
@@ -40,6 +42,13 @@ var mic = function mic(options) {
         formatEncoding = 'S';
     }
     format = formatEncoding + bitwidth + '_' + formatEndian;
+    var extraOptionsForArecord = [];
+    if (periodFrames !== undefined) {
+        extraOptionsForArecord.push('--period-size=' + periodFrames);
+    }
+    if (bufferFrames !== undefined) {
+        extraOptionsForArecord.push('--buffer-size=' + bufferFrames);
+    }
     audioStream.setNumSilenceFramesExitThresh(parseInt(exitOnSilence, 10));
 
     that.start = function start() {
@@ -57,7 +66,7 @@ var mic = function mic(options) {
             }
             else {
               audioProcess = spawn('arecord', ['-t', fileType, '-c', channels, '-r', rate, '-f',
-                                   format, '-D', device], audioProcessOptions);
+                                   format, '-D', device].concat(extraOptionsForArecord), audioProcessOptions);
             }
 
             audioProcess.on('exit', function(code, sig) {


### PR DESCRIPTION
I decided to use bufferFrames and periodFrames because bufferSize is a pretty much burned word.
Changing periodFrames can reduce the output delay caused by the default buffer and period size of arecord drastically when you are streaming the output e.g. directly via multicast to a speaker.
